### PR TITLE
Reliable fragment transmission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.yaml
 !config.sample.yaml
 node_modules
-received_files

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -11,5 +11,4 @@ data_struct:
   #           big amounts of sats. Experiment at your own risk.
   max_data_size: 5242880 # Maximum allowed size for data to be transmitted.
   tlv_key: 293345191 # replace with desired TLV key to insert DataStruct structure into
-  max_fragment_size: 1024 # replace with desired maximum size per fragment
-  min_fragment_size: 512 # replace with desired minimum size per fragment
+  fragment_size: 1024 # replace with desired maximum size per fragment

--- a/src/handle-command.js
+++ b/src/handle-command.js
@@ -2,7 +2,8 @@ const fs = require('fs')
 const {
     sendDataToAddress,
     setDestinationAddress,
-    getDestinationAddress } = require('./write-sats')
+    getDestinationAddress,
+    sendFragmentsSync } = require('./write-sats')
 const { encodeDataStruct, dataToDataStructArray } = require('./utils/data-struct/data-struct')
 const { encodeAppFileMessage, encodeAppTextMessage } = require('./app-protocol/app-protocol')
 
@@ -33,17 +34,9 @@ handlers['send'] = async (args) => {
         const filename = args[1].replace(/^.*[\\\/]/, '')
 
         const appMessageBuf = await encodeAppFileMessage(filename, buff)
-
         const dataStructs = dataToDataStructArray(appMessageBuf)
 
-        dataStructs.forEach(
-            (dataStruct) => {    
-                encodeDataStruct(dataStruct)
-                    .then((buf) => {
-                        sendDataToAddress(getDestinationAddress(), buf)
-                    })
-            }
-        )
+        sendFragmentsSync(dataStructs, 0, 0)
     } catch (e) {
         console.log(e)
     }

--- a/src/utils/data-struct/data-struct.js
+++ b/src/utils/data-struct/data-struct.js
@@ -16,7 +16,7 @@ const dataToDataStructArray = (dataBuffer) => {
     }
     const totalSize = dataBuffer.length
     const fragmentationId = Math.floor(Math.random() * Math.pow(10, 9));
-    const fragmentSize = config.data_struct.max_fragment_bytes
+    const fragmentSize = config.data_struct.fragment_size
 
     let fragmentCount = Math.floor(dataBuffer.length / fragmentSize)
     if (dataBuffer.length % fragmentSize !== 0) {

--- a/src/write-sats.js
+++ b/src/write-sats.js
@@ -64,7 +64,6 @@ const sendPayment = (address, dataBuffer, dataSigBuffer) => {
             // The current status of the stream.
         });
         call.on('end', function () {
-            console.error('SendPaymentV2 failed. Maybe fragment too big.')
             reject()
         });
     })
@@ -92,12 +91,14 @@ const sendFragmentsSync = async (dataStructs, totalSum, totalCost) => {
     let sum = totalSum
     let prom = new Promise(async function (resolve, reject) {
         let buf = await encodeDataStruct(dataStruct)
-        let cost = await sendDataToAddress(getDestinationAddress(), buf)
+        let cost = await sendDataToAddress(getDestinationAddress(), buf).catch(() => {
+            console.log('Fragment too big, SendPaymentV2 failed')
+            reject()
+        })
         totalCost += cost
         sum += dataStruct.payload.length
         console.log("Fragment sent for", cost, "sat(s) |",
             sum, '/', dataStruct.fragment.totalSize, 'B');
-        await sleep(1)
         resolve(0)
     })
     await Promise.all([prom])


### PR DESCRIPTION
- Fix semantics in `config.yaml` related to fragment sizes. Now only 1 value is configured and that's the static size of all fragments.
- Changes fragment transmission operation, now fragments are send in sync. Previously the async burst of requests caused LND to stall.